### PR TITLE
Correcting chassis switch initialization in r2case_probe

### DIFF
--- a/drivers/input/misc/r2chassis.c
+++ b/drivers/input/misc/r2chassis.c
@@ -141,7 +141,7 @@ static int r2case_probe(struct platform_device *ofdev)
                 return -ENOMEM;
         }
 
-        memset(r2case, 0, sizeof(struct input_dev *));
+        memset(r2case, 0, sizeof(struct input_dev));
 
 
         /*


### PR DESCRIPTION
Corrected memset in r2case_probe() to clear the full r2case structure vice only a pointer's worth of memory.
